### PR TITLE
Added wiggle png/gif modifier

### DIFF
--- a/server.js
+++ b/server.js
@@ -396,5 +396,5 @@ app.listen(process.env.PORT);
 //app.listen(8080);
 setInterval(() => {
   http.get(`http://${process.env.PROJECT_DOMAIN}.glitch.me/`);
-  //http.get(`localhost:8080/`);
+  //http.get(`http://localhost:8080/`);
 }, 280000);


### PR DESCRIPTION
Making pngs and gifs wiggle
 ![](https://cdn.discordapp.com/attachments/551812785575690261/642563519535120405/yentPepoShock.gif) ![](https://cdn.discordapp.com/attachments/551812785575690261/642563336667529234/yentLuigiNom.gif)

Known bugs:

- The resulting gif of `[some png] -> [some gif modification] -> wiggle` is about twice as slow as `[some png] -> wiggle -> [some gif modification]`
- Very few gifs result in mysterious glitches e.g. ![](https://cdn.discordapp.com/attachments/551812785575690261/642560221885104139/yentBugcatCry.gif)
For the majority of gifs it works properly though