### PR TITLE
Added slide png/gif modifier

### DIFF
--- a/gifmodify.js
+++ b/gifmodify.js
@@ -525,9 +525,6 @@ exports.createSlidingPNG = function(options) {
     Jimp.read(options.buffer).then(image => {
       let { width, height, encoder } = preparePNGVariables(options, image.bitmap);
       let { interval, direction, shift, shiftSize } = prepareSlidingVariables(options, width);
-      // Flooring to elude weird shift bug
-      width = Math.floor(width);
-      height = Math.floor(height);
       image.resize(width, height);
       getBuffer(encoder.createReadStream()).then(buffer => resolve(buffer));
       setEncoderProperties(encoder, 80);
@@ -637,8 +634,9 @@ function getSizeFromOptions(options) {
 
 function preparePNGVariables(options, image) {
   const {widthModifier, heightModifier} = getSizeFromOptions(options);
-  const width = widthModifier * image.width;
-  const height = heightModifier * image.height;
+  // Flooring to elude rounding errors
+  const width = Math.floor(widthModifier * image.width);
+  const height = Math.floor(heightModifier * image.height;
 
   return {
     width,

--- a/server.js
+++ b/server.js
@@ -201,7 +201,7 @@ function getCommands(options) {
         special.push(command);
         break;
       case 'slide':
-        let direction = 0;
+        let direction = -1; // left
 
         if (option[1] && option[1] === 'right') {
           direction = 1;

--- a/server.js
+++ b/server.js
@@ -151,13 +151,13 @@ app.post('/modifygif', jsonParser, (req, res) => {
   
   processCommands(data)
     .then(buffer => {
-    logger.log('info', 'Processed modified emote', {length: buffer.length});
-    res.status(200);
-    res.send(buffer.toString('base64'));
+      logger.log('info', 'Processed modified emote', {length: buffer.length});
+      res.status(200);
+      res.send(buffer.toString('base64'));
     }).catch(err => {
-    logger.log('warn', 'Failed to modify emote ', err);
-    res.status(400);
-    res.send(err);
+      logger.log('warn', 'Failed to modify emote ', err);
+      res.status(400);
+      res.send(err);
     });
 });
 
@@ -198,6 +198,17 @@ function getCommands(options) {
       case 'rotate':
         command.name = option[0];
         command.param = option[1];
+        special.push(command);
+        break;
+      case 'slide':
+        let direction = 0;
+
+        if (option[1] && option[1] === 'right') {
+          direction = 1;
+        }
+
+        command.name = option[0];
+        command.param = direction;
         special.push(command);
         break;
       case 'spin':
@@ -334,6 +345,10 @@ function processSpecialCommand(command) {
         break;
       case 'wiggle':
         type = command.type === 'gif' ? 'createWigglingGIF' : 'createWigglingPNG';
+        gifmodify[type](command).then(buffer => resolve(buffer)).catch(err => reject(err));
+        break;
+      case 'slide':
+        type = command.type === 'gif' ? 'createSlidingGIF' : 'createSlidingPNG';
         gifmodify[type](command).then(buffer => resolve(buffer)).catch(err => reject(err));
         break;
       default:


### PR DESCRIPTION
Making pngs and gifs slide either from right to left (default) or left to right
![](https://cdn.discordapp.com/attachments/551812785575690261/643107371689705522/yentDogSweat.gif) ![](https://cdn.discordapp.com/attachments/551812785575690261/643107572454391819/yentPepoDance2.gif)

Known bugs:
- Some wide pngs are weirdly curved e.g. ![](https://cdn.discordapp.com/attachments/551812785575690261/643107181369098241/yentBlobMuscle.gif)
